### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
   Give coding agents safe MCP access to linting, testing, formatting, and more. All with one YAML file.
 </h3>
 
+<a href="https://glama.ai/mcp/servers/@scosman/actions_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@scosman/actions_mcp/badge" alt="ActionsMCP MCP server" />
+</a>
+
 ## Overview
 
 1. **Simple setup:** one YAML file is all it takes to create a custom MCP server for your coding agents. Similar to package.json scripts or Github Actions workflows, but commands run as MCP server functions. Add the YAML to your repo to share with your team.


### PR DESCRIPTION
This PR adds a badge for the [ActionsMCP](https://glama.ai/mcp/servers/@scosman/actions_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@scosman/actions_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@scosman/actions_mcp/badge" alt="ActionsMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.