### PR TITLE
Add structured arguments for actions to avoid shlex quoting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Each action in the `actions` array can have the following fields:
 
 - `name` (required): Unique identifier for the tool
 - `description` (required): Human-readable description of what the tool does
-- `command` (required): The CLI command to execute. May include dynamic parameters like `$TEST_FILE_PATH`.
+- `command` (required): The CLI command/program to execute. May include dynamic parameters like `$TEST_FILE_PATH`.
+- `arguments` (optional): Structured argv array. When provided, HooksMCP executes `[command] + arguments` and substitutes parameters in each argv element without `shlex.split`.
 - [`parameters`](#action-parameter-fields) (optional): Definitions of each parameter used in the command.
 - `run_path` (optional): Relative path from project root where the command should be executed. Useful for mono-repos.
 - `timeout` (optional): Timeout in seconds for command execution (default: 60 seconds)
@@ -180,6 +181,22 @@ Allows any string input from the agent without validation. Use with caution:
     - name: "PATTERN"
       type: "insecure_string"
       description: "Pattern to search for"
+```
+
+When passing free-text values (especially values with spaces or quotes), prefer structured `arguments`:
+
+```yaml
+- name: "embedding_search"
+  description: "Search embeddings index"
+  command: "/usr/local/bin/query_embeddings"
+  arguments:
+    - "search"
+    - "--query"
+    - "$QUERY"
+  parameters:
+    - name: "QUERY"
+      type: "insecure_string"
+      description: "Search query text"
 ```
 
 #### required_env_var
@@ -290,7 +307,7 @@ HooksMCP implements several security measures to help improve security of giving
 
 3. **Safe Command Execution**:
    - Uses Python `subprocess.run` with `shell=False` to prevent shell injection
-   - Uses `shlex.split` to properly separate command arguments
+   - Uses `shlex.split` for string `command` mode, or exact `[command] + arguments` when structured `arguments` are configured
    - Implements timeouts to prevent infinite running commands
 
 ### Security Risks

--- a/hooks_mcp/config.py
+++ b/hooks_mcp/config.py
@@ -172,6 +172,7 @@ class Action:
         name: str,
         description: str,
         command: str,
+        arguments: Optional[List[str]] = None,
         parameters: Optional[List[ActionParameter]] = None,
         run_path: Optional[str] = None,
         timeout: int = 60,
@@ -179,6 +180,7 @@ class Action:
         self.name = name
         self.description = description
         self.command = command
+        self.arguments = arguments
         self.parameters = parameters or []
         self.run_path = run_path
         self.timeout = timeout
@@ -189,6 +191,7 @@ class Action:
         name = data.get("name")
         description = data.get("description")
         command = data.get("command")
+        arguments = data.get("arguments")
 
         if not name:
             raise ConfigError("HooksMCP Error: 'name' is required for each action")
@@ -198,6 +201,16 @@ class Action:
             )
         if not command:
             raise ConfigError("HooksMCP Error: 'command' is required for each action")
+        if arguments is not None:
+            if not isinstance(arguments, list):
+                raise ConfigError(
+                    f"HooksMCP Error: 'arguments' must be an array for action '{name}'"
+                )
+            for i, arg in enumerate(arguments):
+                if not isinstance(arg, str):
+                    raise ConfigError(
+                        f"HooksMCP Error: 'arguments[{i}]' must be a string for action '{name}'"
+                    )
 
         parameters = []
         if "parameters" in data:
@@ -234,12 +247,13 @@ class Action:
                 )
 
         return cls(
-            name,
-            description,
-            command,
-            parameters,
-            data.get("run_path"),
-            data.get("timeout", 60),
+            name=name,
+            description=description,
+            command=command,
+            arguments=arguments,
+            parameters=parameters,
+            run_path=data.get("run_path"),
+            timeout=data.get("timeout", 60),
         )
 
 

--- a/hooks_mcp/executor.py
+++ b/hooks_mcp/executor.py
@@ -2,7 +2,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from .config import Action, ParameterType
 from .utils import process_terminal_output, resolve_path, validate_project_path

--- a/hooks_mcp/executor.py
+++ b/hooks_mcp/executor.py
@@ -101,8 +101,8 @@ class CommandExecutor:
         return self._substitute_parameters_in_args(command_args, env_vars)
 
     def _substitute_parameters_in_args(
-        self, command_args: list[str], env_vars: Dict[str, str]
-    ) -> list[str]:
+        self, command_args: List[str], env_vars: Dict[str, str]
+    ) -> List[str]:
         """
         Substitute parameter variables into pre-split argv elements.
 

--- a/hooks_mcp/executor.py
+++ b/hooks_mcp/executor.py
@@ -36,8 +36,8 @@ class CommandExecutor:
         # Validate and prepare parameters
         env_vars = self._prepare_parameters(action, parameters)
 
-        # Parse command and substitute parameters in command args
-        command_args = self._substitute_parameters(action.command, env_vars)
+        # Build command args and substitute parameters in each arg
+        command_args = self._build_command_args(action, env_vars)
 
         # Determine execution directory
         execution_dir = self.project_root
@@ -78,23 +78,41 @@ class CommandExecutor:
                 f"HooksMCP Error: Failed to execute command for action '{action.name}': {str(e)}"
             )
 
-    def _substitute_parameters(self, command: str, env_vars: Dict[str, str]) -> list:
+    def _build_command_args(self, action: Action, env_vars: Dict[str, str]) -> list:
         """
-        Parse command template and substitute parameter variables with their values.
+        Build command argv and substitute parameter variables with their values.
+
+        If action.arguments is provided, argv is constructed as:
+            [action.command] + action.arguments
+        without shlex parsing.
+
+        Otherwise, action.command is parsed with shlex for backwards compatibility.
+        """
+        if action.arguments is not None:
+            return self._substitute_parameters_in_args(
+                [action.command, *action.arguments], env_vars
+            )
+
+        try:
+            command_args = shlex.split(action.command)
+        except ValueError as e:
+            raise ExecutionError(f"HooksMCP Error: Invalid command syntax: {e}")
+
+        return self._substitute_parameters_in_args(command_args, env_vars)
+
+    def _substitute_parameters_in_args(
+        self, command_args: list[str], env_vars: Dict[str, str]
+    ) -> list[str]:
+        """
+        Substitute parameter variables into pre-split argv elements.
 
         Args:
-            command: The command string containing $VARIABLE_NAME placeholders
+            command_args: Pre-split argv elements containing $VARIABLE_NAME placeholders
             env_vars: Dictionary of variable names to values
 
         Returns:
             List of command arguments with variables substituted
         """
-        # First parse the command template to understand shell syntax
-        try:
-            command_args = shlex.split(command)
-        except ValueError as e:
-            raise ExecutionError(f"HooksMCP Error: Invalid command syntax: {e}")
-
         # Sort parameter names by length (descending) to handle collisions
         # This ensures $PREFIX_SUFFIX is processed before $PREFIX
         sorted_params = sorted(env_vars.keys(), key=len, reverse=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -296,6 +296,74 @@ actions:
         assert action2.command == "echo Hello"
         assert action2.timeout == 60  # Default timeout
 
+    def test_valid_config_action_with_arguments(self):
+        """Test parsing an action with structured arguments."""
+        yaml_content = """
+actions:
+  - name: "embedding_search"
+    description: "Search embeddings"
+    command: "/usr/local/bin/query_embeddings"
+    arguments:
+      - "search"
+      - "--query"
+      - "$QUERY"
+    parameters:
+      - name: "QUERY"
+        type: "insecure_string"
+        description: "Search query"
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config = HooksMCPConfig.from_yaml(f.name)
+            Path(f.name).unlink()
+
+        assert len(config.actions) == 1
+        action = config.actions[0]
+        assert action.command == "/usr/local/bin/query_embeddings"
+        assert action.arguments == ["search", "--query", "$QUERY"]
+
+    def test_invalid_config_action_arguments_must_be_array(self):
+        """Test that non-array action arguments are rejected."""
+        yaml_content = """
+actions:
+  - name: "bad_action"
+    description: "Invalid arguments type"
+    command: "echo"
+    arguments: "--query $QUERY"
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            with pytest.raises(ConfigError) as context:
+                HooksMCPConfig.from_yaml(f.name)
+            Path(f.name).unlink()
+
+        assert "'arguments' must be an array" in str(context.value)
+
+    def test_invalid_config_action_arguments_items_must_be_strings(self):
+        """Test that action arguments must be string items."""
+        yaml_content = """
+actions:
+  - name: "bad_action"
+    description: "Invalid arguments item type"
+    command: "echo"
+    arguments:
+      - "hello"
+      - 123
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            with pytest.raises(ConfigError) as context:
+                HooksMCPConfig.from_yaml(f.name)
+            Path(f.name).unlink()
+
+        assert "'arguments[1]' must be a string" in str(context.value)
+
     def test_valid_config_with_prompts_inline(self):
         """Test parsing a configuration with inline prompts."""
         yaml_content = """

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -354,3 +354,27 @@ class TestExecutor:
 
         assert result["status_code"] == 0
         assert result["stderr"] == ""
+
+    def test_execute_command_with_structured_arguments_preserves_query_argv(self):
+        """Test arguments mode keeps quoted free text as a single argv element."""
+        action = Action(
+            name="argv_query_test",
+            description="Verify argv query handling",
+            command="python",
+            arguments=[
+                "-c",
+                "import sys; print(repr(sys.argv[1]))",
+                "$QUERY",
+            ],
+            parameters=[
+                ActionParameter(
+                    "QUERY", ParameterType.INSECURE_STRING, "Query to pass through"
+                )
+            ],
+        )
+
+        query = 'find "quoted text" across files'
+        result = self.executor.execute_action(action, {"QUERY": query})
+
+        assert result["status_code"] == 0
+        assert result["stdout"] == repr(query)


### PR DESCRIPTION
This adds optional `arguments` (list of argv items) to action configuration.

If `arguments` is provided, the executor builds argv as [command] + arguments and performs parameter substitution per-argument, without parsing a single command string via shlex. This makes free-text parameters robust (spaces and quotes no longer break tool calls).

Backwards compatible: existing string `command` continues to work unchanged.

Example config:
command: /usr/local/bin/query_embeddings
arguments: ["search","--index","/home/ss/index","--results-only","--query","$QUERY"]

Fixes: #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional arguments field for actions to pass structured argv elements; parameter substitution applies per-argument and preserves spacing/quotes.

* **Documentation**
  * Clarified command vs. arguments execution modes, updated env var guidance (including .env), and explained when shlex splitting is or isn't applied.

* **Tests**
  * Added tests for parsing/validation of arguments and for execution preserving argv elements exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->